### PR TITLE
chore(s3): updated transaction object lifecycle

### DIFF
--- a/terraform/aws_bucket.tf
+++ b/terraform/aws_bucket.tf
@@ -1,5 +1,38 @@
 resource "aws_s3_bucket" "main" {
   bucket = "dca-manager"
+
+  lifecycle_rule {
+    enabled = true
+    id      = "autoclean_pending_transactions"
+    prefix  = local.lambda_s3_pending_transaction_prefix
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+  }
+
+
+  lifecycle_rule {
+    enabled = true
+    id      = "autoclean_processed_transactions"
+    prefix  = local.lambda_s3_processed_transaction_prefix
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+  }
 }
 
 resource "aws_s3_bucket_object" "config" {


### PR DESCRIPTION
At those points, they should already be loaded into the Hudi
Table for any analytics processing.